### PR TITLE
Moving cursor after editorScroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "simple-vim",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
                 "when": "editorTextFocus"
             },
             {
+                "key": "ctrl+[",
+                "command": "extension.simpleVim.escapeKey",
+                "when": "editorTextFocus"
+            },
+            {
                 "key": "ctrl+r",
                 "command": "redo",
                 "when": "editorTextFocus && !extension.simpleVim.insertMode"

--- a/src/scroll_commands.ts
+++ b/src/scroll_commands.ts
@@ -1,9 +1,21 @@
 import * as vscode from 'vscode';
 
+function executeMoveCommand(
+    command: 'editorScroll' | 'cursorMove',
+    options: { to: string, by: string },
+) {
+    vscode.commands.executeCommand(command, options);
+}
+
 function editorScroll(to: string, by: string) {
-    vscode.commands.executeCommand('editorScroll', {
-        to: to,
-        by: by,
+    executeMoveCommand('editorScroll', {
+        to,
+        by,
+    });
+
+    executeMoveCommand('cursorMove', {
+        to: 'viewPortCenter',
+        by: 'line',
     });
 }
 


### PR DESCRIPTION
Resolves #5 

and added `Ctrl+[` shortcut to Escape key, which is quite useful for users having Macbook Pro with Touch bar.