### PR TITLE
Add beginning and end of line operator ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ OperatorRanges select a range for an Operator to act on. They must be used in No
 | `B` | From cursor to beginning of previous word (including punctuation). |
 | `e` | From cursor to end of next word. |
 | `E` | From cursor to end of next word (including punctuation). |
+| `$` | From cursor to end of line. |
+| `_` | From cursor to beginning of line excluding leading white space. |
 | `iw` | Word under cursor. |
 | `iW` | Word (including punctuation) under cursor. |
 | `aw` | Word under cursor and whitespace after. |

--- a/src/actions/operator_ranges.ts
+++ b/src/actions/operator_ranges.ts
@@ -59,6 +59,16 @@ export const operatorRanges: OperatorRange[] = [
         }
     }),
 
+    createOperatorRangeExactKeys(['_'], false, (vimState, document, position) => {
+        const line = document.lineAt(position.line);
+        const beginning = position.with({ character: line.firstNonWhitespaceCharacterIndex });
+        return new vscode.Range(position, beginning);
+    }),
+
+    createOperatorRangeExactKeys(['$'], false, (vimState, document, position) => {
+        return new vscode.Range(position, positionUtils.lineEnd(document, position));
+    }),
+
     createOperatorRangeExactKeys(['w'], false, createWordForwardHandler(wordRanges)),
     createOperatorRangeExactKeys(['W'], false, createWordForwardHandler(whitespaceWordRanges)),
 


### PR DESCRIPTION
I added operator ranges for "_" and "$" so you can do things like `d$` to delete to the end of a line.