### PR TITLE
Add keybind "ctrl+[" to go back to normal mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
                 "when": "editorTextFocus"
             },
             {
+                "key": "ctrl+[",
+                "command": "extension.simpleVim.escapeKey",
+                "when": "editorTextFocus"
+            },
+            {
                 "key": "ctrl+r",
                 "command": "redo",
                 "when": "editorTextFocus && !extension.simpleVim.insertMode"


### PR DESCRIPTION
Escape key is far from home position. I would like to use "ctrl+[" keybinding like real vim.